### PR TITLE
Ability to use seneca plugins with express requests and seneca messages 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,6 +16,10 @@ npm install --save seneca-web
 npm install --save seneca-web-adapter-express
 ```
 
+##UPD
+
+Added ability to use plugin with express requests and seneca messages.
+
 ## Usage
 
 Please refer to the seneca-web documentation on how to load routes.

--- a/seneca-web-adapter-express.js
+++ b/seneca-web-adapter-express.js
@@ -56,17 +56,12 @@ function handleRoute (seneca, options, request, reply, route, next) {
     // This is what the seneca handler will get
     // Note! request$ and response$ will be stripped
     // if the message is sent over transport.
-    const payload = {
-      request$: request,
-      response$: reply,
-      args: {
-        body: body,
-        route: route,
-        params: request.params,
-        query: request.query,
-        user: request.user || null
-      }
-    }
+    const payload = Object.assign(
+        {},
+        request.params,
+        request.query,
+        {request$: request, response$: reply, route$: route, body}
+    )
 
     // Call the seneca action specified in the config
     seneca.act(route.pattern, payload, (err, response) => {

--- a/seneca-web-adapter-express.js
+++ b/seneca-web-adapter-express.js
@@ -60,6 +60,7 @@ function handleRoute (seneca, options, request, reply, route, next) {
       {},
       request.params,
       request.query,
+      body !== null && typeof body === 'object' ? body : {},
       {
         request$: request,
         response$: reply,

--- a/seneca-web-adapter-express.js
+++ b/seneca-web-adapter-express.js
@@ -57,10 +57,20 @@ function handleRoute (seneca, options, request, reply, route, next) {
     // Note! request$ and response$ will be stripped
     // if the message is sent over transport.
     const payload = Object.assign(
-        {},
-        request.params,
-        request.query,
-        {request$: request, response$: reply, route$: route, body}
+      {},
+      request.params,
+      request.query,
+      {
+        request$: request,
+        response$: reply,
+        args: {
+          body: body,
+          route: route,
+          params: request.params,
+          query: request.query,
+          user: request.user || null
+        }
+      }
     )
 
     // Call the seneca action specified in the config

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -98,6 +98,68 @@ describe('express', () => {
     })
   })
 
+  it('check get request payload', (done) => {
+    var config = {
+      routes: {
+        pin: 'role:test,cmd:*',
+        map: {
+          ask: {
+            GET: true
+          }
+        }
+      }
+    }
+
+    si.add('role:test,cmd:ask', (msg, reply) => {
+      reply(null, {answer: parseInt(msg.answer, 0)})
+    })
+
+    si.act('role:web', config, (err, reply) => {
+      if (err) return done(err)
+
+      Request.get('http://127.0.0.1:3000/ask?answer=42', (err, res, body) => {
+        if (err) return done(err)
+
+        body = JSON.parse(body)
+
+        expect(body.answer).to.be.equal(42)
+        done()
+      })
+    })
+  })
+
+  it('check post request payload', (done) => {
+    var config = {
+      options: {
+        parseBody: false
+      },
+      routes: {
+        pin: 'role:test,cmd:*',
+        map: {
+          ask: {
+            POST: true
+          }
+        }
+      }
+    }
+
+    app.use(BodyParser.json())
+
+    si.add('role:test,cmd:ask', (msg, reply) => {
+      reply(null, {answer: msg.answer})
+    })
+
+    si.act('role:web', config, (err, reply) => {
+      if (err) return done(err)
+
+      Request.post('http://127.0.0.1:3000/ask', {json: {answer: 42}}, (err, res, body) => {
+        if (err) return done(err)
+        expect(body.answer).to.be.equal(42)
+        done()
+      })
+    })
+  })
+
   it('post without body parser defined', (done) => {
     var config = {
       routes: {

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -111,7 +111,7 @@ describe('express', () => {
     }
 
     si.add('role:test,cmd:echo', (msg, reply) => {
-      reply(null, {value: msg.args.body})
+      reply(null, {value: msg.body})
     })
 
     si.act('role:web', config, (err, reply) => {
@@ -143,7 +143,7 @@ describe('express', () => {
     app.use(BodyParser.json())
 
     si.add('role:test,cmd:echo', (msg, reply) => {
-      reply(null, msg.args.body)
+      reply(null, msg.body)
     })
 
     si.act('role:web', config, (err, reply) => {

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -111,7 +111,7 @@ describe('express', () => {
     }
 
     si.add('role:test,cmd:echo', (msg, reply) => {
-      reply(null, {value: msg.body})
+      reply(null, {value: msg.args.body})
     })
 
     si.act('role:web', config, (err, reply) => {
@@ -143,7 +143,7 @@ describe('express', () => {
     app.use(BodyParser.json())
 
     si.add('role:test,cmd:echo', (msg, reply) => {
-      reply(null, msg.body)
+      reply(null, msg.args.body)
     })
 
     si.act('role:web', config, (err, reply) => {

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -160,6 +160,34 @@ describe('express', () => {
     })
   })
 
+  it('check post request payload without body parser', (done) => {
+    var config = {
+      routes: {
+        pin: 'role:test,cmd:*',
+        map: {
+          ask: {
+            POST: true
+          }
+        }
+      }
+    }
+
+
+    si.add('role:test,cmd:ask', (msg, reply) => {
+      reply(null, {answer: msg.answer})
+    })
+
+    si.act('role:web', config, (err, reply) => {
+      if (err) return done(err)
+
+      Request.post('http://127.0.0.1:3000/ask', {json: {answer: 42}}, (err, res, body) => {
+        if (err) return done(err)
+        expect(body.answer).to.be.equal(undefined)
+        done()
+      })
+    })
+  })
+
   it('post without body parser defined', (done) => {
     var config = {
       routes: {

--- a/test/secured-route.test.js
+++ b/test/secured-route.test.js
@@ -39,7 +39,7 @@ const Routes = [{
 
 function AuthPlugin () {
   const si = this
-  si.add('role:admin,cmd:profile', (msg, cb) => cb(null, msg.request$.user))
+  si.add('role:admin,cmd:profile', (msg, cb) => cb(null, msg.args.user))
   si.add('role:admin,cmd:home', (msg, cb) => cb(null, {msg: 'please login'}))
   return {name: 'AuthPlugin'}
 }

--- a/test/secured-route.test.js
+++ b/test/secured-route.test.js
@@ -39,7 +39,7 @@ const Routes = [{
 
 function AuthPlugin () {
   const si = this
-  si.add('role:admin,cmd:profile', (msg, cb) => cb(null, msg.args.user))
+  si.add('role:admin,cmd:profile', (msg, cb) => cb(null, msg.request$.user))
   si.add('role:admin,cmd:home', (msg, cb) => cb(null, {msg: 'please login'}))
   return {name: 'AuthPlugin'}
 }


### PR DESCRIPTION
Changed payload structure of the express requests payload. This allows us to do next things:

- Do request like `http://localhost:3000/role/cmd?something=true`
*inside a seneca plugin: 
`function (msg, resp) {
     console.log(msg.something);
}`

This will work for POST and GET requests and we will able to use the same plugin's code for seneca `.act('role:arole,cmd:*')` method.