### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 docs/annotated
 docs/coverage
 .nyc_output
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js][] plugin
+
+# @seneca/web-adapter-express
+
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
+
+## Install
+
+```sh
+npm install seneca-web-adapter-express
+```
+
+## Quick Example
+
+```js
+var SenecaWeb = require('seneca-web')
+var Express = require('express')
+var context = Express.Router()
+require('seneca')()
+  .use(SenecaWeb, { context: context, adapter: require('seneca-web-adapter-express') })
+```
+
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+Express adapter for [seneca-web](https://github.com/senecajs/seneca-web). Maps HTTP routes to Seneca actions.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
+
+## API
+
+Configured via [seneca-web](https://github.com/senecajs/seneca-web) options.
+
+## Contributing
+
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
+```sh
+npm run test
+```
+
+## Background
+
+Part of the [seneca-web](https://github.com/senecajs/seneca-web) adapter family.
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Coverage Status][coveralls-badge]][coveralls-url]
+[![Dependency Status][david-badge]][david-url]
+[Sponsor]: http://nearform.com
+[Logo]: http://senecajs.org/files/assets/seneca-logo.png
+[npm-badge]: https://badge.fury.io/js/seneca-web-adapter-express.svg
+[npm-url]: https://badge.fury.io/js/seneca-web-adapter-express
+[travis-badge]: https://travis-ci.org/senecajs/seneca-web-adapter-express.svg?branch=master
+[travis-url]: https://travis-ci.org/senecajs/seneca-web-adapter-express
+[coveralls-badge]: https://coveralls.io/repos/github/senecajs/seneca-web-adapter-express/badge.svg?branch=master
+[coveralls-url]: https://coveralls.io/github/senecajs/seneca-web-adapter-express?branch=master
+[david-badge]: https://david-dm.org/senecajs/seneca-web-adapter-express.svg
+[david-url]: https://david-dm.org/senecajs/seneca-web-adapter-express
+[Senecajs org]: https://github.com/senecajs/
+[MIT]: ./LICENSE

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-web-adapter-express",
+  "name": "@seneca/web-adapter-express",
   "version": "1.2.1",
   "description": "seneca-web adapter for express",
   "keywords": [


### PR DESCRIPTION
## What changed
- Renamed default branch to `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`